### PR TITLE
fix typo in readme for doing the common import of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kotlin {
   sourceSets {
         commonMain { //   <---  name may vary on your project
             dependencies {
-                implementation "org.reduxkotlin:presenter-middlware:0.2.8"
+                implementation "org.reduxkotlin:presenter-middleware:0.2.8"
             }
         }
  }


### PR DESCRIPTION
# Overview

Was interested in trying to use this library and noticed there was a typo in the import statement of the common module